### PR TITLE
Safe label name handling

### DIFF
--- a/label.sh
+++ b/label.sh
@@ -62,4 +62,4 @@ ALL_LABELS="$EXTRA_SMALL_LABEL,$SMALL_LABEL,$MEDIUM_LABEL,$LARGE_LABEL,$EXTRA_LA
 echo "Removing $ALL_LABELS labels and adding $LABEL"
 
 gh pr edit $PR_NUMBER --remove-label "$ALL_LABELS"
-gh pr edit $PR_NUMBER --add-label $LABEL
+gh pr edit $PR_NUMBER --add-label "$LABEL"


### PR DESCRIPTION
Add quotes around the label being added so labels that have spaces don't cause the action to error