### PR TITLE
Return tiny label when there's only deletion

### DIFF
--- a/label.sh
+++ b/label.sh
@@ -21,8 +21,8 @@ fi
 if [[ "$DIFF_OUTPUT" =~ ([0-9]+)( insertion) ]]; then
   INSERTIONS=${BASH_REMATCH[1]}
 else
-  echo "Could not extract insertions from \"$DIFF_OUTPUT\" - exiting..."
-  exit 0
+  # If the diff only shows deletions, the word 'insertions' is omitted, which breaks the regex above.
+  INSERTIONS=0
 fi
 
 echo "Insertion count: $INSERTIONS"


### PR DESCRIPTION
### Problem:
When the difference between the base branch and the head contains only deletion, the action fails because the diff statement doesn't contain the word "insertion".

Example is extracted from Terminal's output:
```
➜  diff-stats-action git:(return-label-when-only-deletion) ✗ git diff --stat | tail -1 
 1 file changed, 1 deletion(-)  
```

### Solution:
Could create another label for this case and return that but given the main goal of this action is to represent a label that implies how hard it is to review a PR, I think just returning the tiny label is reasonable. Therefore, instead of exiting with code zero, decided to assign `INSERTIONS` to zero so that the tiny label gets selected.